### PR TITLE
Point to centos-release-opstools rpm

### DIFF
--- a/testing-repo.txt
+++ b/testing-repo.txt
@@ -5,7 +5,6 @@ shared resource and not intended for end user consumption at all.
 
 == Repo file for CentOS
 
-Place a copy of https://raw.githubusercontent.com/centos-opstools/opstools-repo/master/opstools.repo[this repo file] to your /etc/yum.repos.d.
+There is a rpm for managing repositories. If repository locations change, they'll get updated by the release rpm:
 
-or use 
   yum install http://buildlogs.centos.org/centos/7/opstools/x86_64/common/centos-release-opstools-1-2.el7.noarch.rpm

--- a/testing-repo.txt
+++ b/testing-repo.txt
@@ -6,3 +6,6 @@ shared resource and not intended for end user consumption at all.
 == Repo file for CentOS
 
 Place a copy of https://raw.githubusercontent.com/centos-opstools/opstools-repo/master/opstools.repo[this repo file] to your /etc/yum.repos.d.
+
+or use 
+  yum install http://buildlogs.centos.org/centos/7/opstools/x86_64/common/centos-release-opstools-1-2.el7.noarch.rpm


### PR DESCRIPTION
now there is a release rpm, and thus we should use it.
